### PR TITLE
Reduce spam.

### DIFF
--- a/fmn/lib/defaults.py
+++ b/fmn/lib/defaults.py
@@ -119,21 +119,13 @@ def create_defaults_for(session, user, only_for=None):
         if not pref:
             pref = fmn.lib.models.Preference.create(session, user, context)
 
-        # Provide one catchall before adding the more specific rules below
-        name = 'Anything involving my username'
-        rule_path = 'fmn.rules:user_filter'
-        filt = fmn.lib.models.Filter.create(session, name)
-        filt.add_rule(session, valid_paths, rule_path, fasnick=nick)
-        pref.add_filter(session, filt)
-
         # Add rules that look for this user
         qualifier_path = 'fmn.rules:user_filter'
         for name, rule_path in generic_rule_path_defaults:
             filt = fmn.lib.models.Filter.create(session, name)
             filt.add_rule(session, valid_paths, rule_path)
             filt.add_rule(session, valid_paths, qualifier_path, fasnick=nick)
-
-            pref.add_filter(session, filt)
+            pref.add_filter(session, filt, notify=False)
 
         # Add rules that look for this user's packages
         qualifier_path = 'fmn.rules:user_package_filter'
@@ -141,5 +133,11 @@ def create_defaults_for(session, user, only_for=None):
             filt = fmn.lib.models.Filter.create(session, name)
             filt.add_rule(session, valid_paths, rule_path)
             filt.add_rule(session, valid_paths, qualifier_path, fasnick=nick)
+            pref.add_filter(session, filt, notify=False)
 
-            pref.add_filter(session, filt)
+        # Lastly, provide one catchall
+        name = 'Anything involving my username'
+        rule_path = 'fmn.rules:user_filter'
+        filt = fmn.lib.models.Filter.create(session, name)
+        filt.add_rule(session, valid_paths, rule_path, fasnick=nick)
+        pref.add_filter(session, filt, notify=True)

--- a/fmn/lib/models.py
+++ b/fmn/lib/models.py
@@ -581,11 +581,12 @@ class Preference(BASE):
         session.commit()
         self.notify(self.openid, self.context_name, "filters")
 
-    def add_filter(self, session, filter):
+    def add_filter(self, session, filter, notify=True):
         self.filters.append(filter)
         session.flush()
         session.commit()
-        self.notify(self.openid, self.context_name, "filters")
+        if notify:
+            self.notify(self.openid, self.context_name, "filters")
 
     def has_filter_name(self, session, filter_name):
         for filter in self.filters:


### PR DESCRIPTION
This adds a notify boolean to one of the Preference modifiers that will let us
turn off fedmsg messages for all but one of the initial operations that goes
into creating a new account.  This should reduce spam on the message bus.

This is especially important because these messages cause the fmn backend to
_invalidate its own cache_, thus slowing it down dramatically.  There is no
need for it to invalidate its own cache _20 times_ for a new user.  It should
only need to do it once.
