### PR TITLE
Add option to load-preferences to omit disabled accounts.

### DIFF
--- a/fmn/lib/__init__.py
+++ b/fmn/lib/__init__.py
@@ -90,7 +90,7 @@ def matches(filter, message, valid_paths, config):
     return True
 
 
-def load_preferences(session, config, valid_paths):
+def load_preferences(session, config, valid_paths, cull_disabled=False):
     """ Every rule for every filter for every context for every user.
 
     Any preferences in the DB that are for contexts that are disabled in the
@@ -99,8 +99,11 @@ def load_preferences(session, config, valid_paths):
     This is an expensive query that loads, practically, the whole database.
     """
     preferences = session.query(fmn.lib.models.Preference).all()
-    return [preference.__json__() for preference in preferences
-            if preference.context.name in config['fmn.backends']]
+    return [preference.__json__() for preference in preferences if (
+        preference.context.name in config['fmn.backends'] and (
+            not cull_disabled or preference.enabled
+        )
+    )]
 
 
 def load_rules(root='fmn.rules'):


### PR DESCRIPTION
This should provide more optimization for the fmn backend.

Currently, it holds a cache of the preferences of every user, and for every
message that comes by, it evaluates the rules for every user.  This
introduces some unnecessary steps when, for instance, @nirik has his irc
message delivery disabled.  We still evaluate _all_ of his irc rules
against _every_ message
(including the thousands of secondary arch koji messages that no-one is
interested in being notified about).

By removing filters such as @nirik's disabled irc rules from the
message-by-message considerations, we should see some small performance
increase.
