### PR TITLE
Cache the results of rules for each message.

### DIFF
--- a/fmn/lib/models.py
+++ b/fmn/lib/models.py
@@ -246,15 +246,19 @@ class Rule(BASE):
             'created_on': self.created_on,
             'code_path': self.code_path,
             'arguments': self.arguments,
+            'cache_key': self.cache_key,
         }
         if reify:
             result['fn'] = fedmsg.utils.load_class(str(self.code_path))
         return result
 
-
     def __repr__(self):
         return "<fmn.lib.models.Rule: %r(**%r)>" % (
             self.code_path, self.arguments)
+
+    @property
+    def cache_key(self):
+        return hashlib.sha256(self.code_path + self._arguments).hexdigest()
 
     @hybrid_property
     def arguments(self):


### PR DESCRIPTION
..then dispose of that cache once we're finished with each message.

A typical rule is "is this a koji message?"  Say we have 500 users, for
every message that comes in we're going to call that function 500 \* 2 times
(once for email and once for IRC).  This builds a little cache at the
beginning of processing each message where we can store that result and
re-use it for each user/context.  We then throw it away and start over when
we're done processing that message.

**Also**:

Instantiate rule code_paths at load-time instead of consume-time.
