### PR TITLE
Revamped defaults.

### DIFF
--- a/fmn/lib/defaults.py
+++ b/fmn/lib/defaults.py
@@ -3,84 +3,278 @@ import fmn.lib.models
 
 log = logging.getLogger(__name__)
 
-generic_rule_path_defaults = [
+# This is a list of rules that we'll use to exclude certain message types.
+# Our defaults work by saying first "give me any message mentioning my username
+# or any package that I maintain *except* for messages that match any of the
+# following exclusion rules".  These lists are broken into three kinds:
+# - exclusion_packages (rules to exclude a message if it matches a package of
+#                       mine).
+# - exclusion_username (rules to exclude a message if it matches my username).
+# - exclusion_mutual (rules to exclude a message for both of the default
+#                     filters)
 
-    # Intentionally leaving this one out of the defaults
-    #('My ansible playbook runs', 'fmn.rules.....')
-
-    # I am intentionally leaving out:
-    #   - ansible
-    #   - compose
-    #   - fedocal
-    #   - meetbot
-
-    ('My askbot posts', 'fmn.rules:askbot_post_edited'),
-
-    ('My bodhi comments', 'fmn.rules:bodhi_update_comment'),
-
-    ('My wiki edits', 'fmn.rules:wiki_article_edit'),
-    ('My wiki uploads', 'fmn.rules:wiki_upload_complete'),
-
-    ('My copr builds', 'fmn.rules:copr_build_end'),
-
-    ('Edits to my fas account', 'fmn.rules:fas_user_update'),
-    ('Role changes for my fas account', 'fmn.rules:fas_role_update'),
-
-    ('Badges!', 'fmn.rules:fedbadges_badge_award'),
-
-    ('My blog posts!', 'fmn.rules:planet_post_new'),
-
-    ('My Koji scratch builds',
-     'fmn.rules:koji_scratch_build_state_change'),
+exclusion_packages = [
+    # If this is a message about a package of mine, **and** i'm responsible for
+    # it, then don't trigger this filter.  Rely on the other one.
+    'user_filter',
 ]
 
-package_rule_path_defaults = [
-    ('Buildroot overrides on my packages',
-     'fmn.rules:bodhi_buildroot_override_tag'),
-    ('Bodhi comments on my packages',
-     'fmn.rules:bodhi_update_comment'),
-    ('Bodhi requests for testing on packages I own',
-     'fmn.rules:bodhi_update_request_testing'),
-    ('Bodhi requests for stable on packages I own',
-     'fmn.rules:bodhi_update_request_stable'),
-    ('Bodhi request revocations on packages I own',
-     'fmn.rules:bodhi_update_request_revoke'),
-    ('Bodhi requests to obsolete updates I own',
-     'fmn.rules:bodhi_update_request_obsolete'),
-    ('Bodhi requests to unpush updates of packages I own',
-     'fmn.rules:bodhi_update_request_unpush'),
+exclusion_username = [
+    # Don't tell me about my own bodhi activity, but do tell me if other people
+    # do bodhi stuff to my packages.
+    'bodhi_buildroot_override_untag',
+    'bodhi_buildroot_override_tag',
+    'bodhi_update_request_stable',
+    'bodhi_update_request_obsolete',
+    'bodhi_update_request_testing',
+    'bodhi_update_request_unpush',
+    'bodhi_update_request_revoke',
+    ## Except, comments.  Comments are nice to get.
+    #'bodhi_update_comment',
 
-    ('Koji builds for packages I own',
-     'fmn.rules:koji_build_state_change'),
+    # Don't tell me about my own bugzilla activity, but I do want to know if
+    # other people act on bugs on my packages.
+    'bugzilla_bug_new',
+    'bugzilla_bug_update',
 
-    ('SCM commits to packages that I own',
-     'fmn.rules:git_receive'),
-    ('New sources uploaded for packages that I own',
-     'fmn.rules:git_lookaside_new'),
-    ('New git branches created for packages that I own',
-     'fmn.rules:git_branch'),
+    # Exclude fedorahosted notifications by default.  No need to notify me of
+    # my own activity.
+    'trac_git_receive',
+    'trac_ticket_new',
+    'trac_wiki_page_new',
+    'trac_ticket_delete',
+    'trac_wiki_page_version_delete',
+    'trac_wiki_page_delete',
+    'trac_wiki_page_rename',
+    'trac_ticket_update',
+    'trac_wiki_page_update',
+    'trac_hosted_filter',
 
-    ('New Tagger tags on packages I own',
-     'fmn.rules:fedoratagger_tag_create'),
-    ('Tagger votes on packages I own',
-     'fmn.rules:fedoratagger_tag_update'),
-    ('Tagger rating changes on packages I own',
-     'fmn.rules:fedoratagger_tag_create'),
+    # Ignore dist-git scm messages if I am responsible for them, but I *do*
+    # want to get notified if someone else pushes to a package that I own.
+    'git_branch',
+    'git_receive',
+    'git_mass_branch_complete',
+    'git_mass_branch_start',
+    'git_lookaside_new',
+    'git_pkgdb2branch_complete',
+    'git_pkgdb2branch_start',
 
-    ('ACL updates on packages I own',
-     'fmn.rules:pkgdb_acl_update'),
-    ('Users removed from packages I own',
-     'fmn.rules:pkgdb_acl_user_remove'),
-    ('New branches for packages I own',
-     'fmn.rules:pkgdb_branch_clone'),
-    ('Critpath status changes to packages I own',
-     'fmn.rules:pkgdb_critpath_update'),
-    ('Owner changes to packages I own',
-     'fmn.rules:pkgdb_owner_update'),
-    ('Retirement of packages I own',
-     'fmn.rules:pkgdb_package_retire'),
-    ('pkgdb metadata updates to packages I own',
-     'fmn.rules:pkgdb_package_update'),
+    # Don't bother notifying me of my own github activity
+    'github_issue_reopened',
+    'github_pull_request_closed',
+    'github_commit_comment',
+    'github_pull_request_review_comment',
+    'github_issue_comment',
+    'github_create',
+    'github_delete',
+    'github_push',
+    'github_watch',
+    # Except for this one.  It is useful to get travis-ci information forwarded
+    #'github_status',
+    # And these two, which are neat to see.
+    #'github_webhook',
+    #'github_fork',
+
+    # Ignore all FMN stuff that you do yourself.
+    'fmn_filter_update',
+    'fmn_preference_update',
+    'fmn_confirmation_update',
+
+    # Ignore all meetbot stuff about meetings I am involved in.  bocecha
+    # pointed it out that this was ridiculous.
+    'meetbot_meeting_complete',
+    'meetbot_meeting_start',
+    'meetbot_meeting_topic_update',
+
+    ## No need to notify me about any fedocal stuff that I do.
+    'fedocal_calendar_clear',
+    'fedocal_calendar_create',
+    'fedocal_calendar_delete',
+    'fedocal_calendar_update',
+    'fedocal_meeting_reminder',
+    'fedocal_meeting_create',
+    'fedocal_meeting_delete',
+    'fedocal_meeting_update',
+
+    ## Go ahead and ignore all pkgdb stuff that *I* do myself, but I do want to
+    ## be notified if someone else does something with respect to one of my
+    ## packages there.
+    'pkgdb_collection_update',
+    'pkgdb_package_branch_new',
+    'pkgdb_package_new',
+    'pkgdb_acl_delete',
+    'pkgdb_package_branch_request',
+    'pkgdb_package_new_request',
+    'pkgdb_acl_update',
+    'pkgdb_package_update',
+    'pkgdb_owner_update',
+    'pkgdb_package_update_status',
+    'pkgdb_package_branch_delete',
+    'pkgdb_package_delete',
+    'pkgdb_package_monitor_update',
+    'pkgdb_package_critpath_update',
+    'pkgdb_admin_action_status_update',
+    'pkgdb_branch_complete',
+    'pkgdb_collection_new',
+    'pkgdb_branch_start',
+
+    # Ignore all of my own tagger stuff
+    'fedoratagger_tag_create',
+    'fedoratagger_user_rank_update',
+    'fedoratagger_usage_toggle',
+    'fedoratagger_tag_update',
+    'fedoratagger_rating_update',
+
+    # Ignore all of my own anitya stuff
+    'anitya_distro_update',
+    'anitya_distro_add',
+    'anitya_mapping_deleted',
+    'anitya_mapping_new',
+    'anitya_new_update',
+    'anitya_project_update',
+    'anitya_info_update',
+    'anitya_project_add',
+    'anitya_project_deleted',
+    'anitya_project_add_tried',
+    'anitya_mapping_update',
+
+    # Ignore all of my own wiki stuff.
+    'wiki_article_edit',
+    'wiki_upload_complete',
+
+]
+exclusion_mutual = [
+    # This is noisy for admins.  Keep only the 'completed' ones which is nice
+    # for long-running playbooks.
+    'playbook_started',
+
+    # No need to notify about your own askbot activity
+    'askbot_post_deleted',
+    'askbot_post_edited',
+    'askbot_post_flagged_offensive',
+    'askbot_post_unflagged_offensive',
+    'askbot_tag_update',
+
+    # Ignore the spammy fedbadges stuff, but keep the badge.award message
+    'fedbadges_person_first_login',
+    'fedbadges_person_rank_advance',
+
+    # No need to tell me about copr starts, I just want to know about completed
+    # stuff.
+    'copr_build_end',
+    'copr_build_failed',
+    'copr_build_skipped',
+    #'copr_build_start',
+    'copr_build_success',
+    #'copr_chroot_start',
+    #'copr_worker_create',
+
+    ## No need to tell me about any fedora-elections stuff, but this should
+    ## never match anyways (it won't relate to my username or a package of
+    ## mine).  Comment it out here to keep the list shorter and easier to read
+    ## for users.
+    #'fedora_elections_candidate_new',
+    #'fedora_elections_candidate_delete',
+    #'fedora_elections_candidate_edit',
+    #'fedora_elections_election_new',
+    #'fedora_elections_election_edit',
+
+    ## Actually, I want to know about *all* fas stuff since its so
+    ## account-sensitive.  i.e., if someone else changes my fas details, I want
+    ## to be notified.
+    #'fas_group_update',
+    #'fas_group_member_apply',
+    #'fas_user_create',
+    #'fas_group_member_sponsor',
+    #'fas_user_update',
+    #'fas_group_member_remove',
+    #'fas_role_update',
+    #'fas_group_create',
+
+    ## No need to notify about any fedimg stuff, but this should never match
+    ## anyways so we leave it out to keep the list shorter.
+    #'fedimg_image_test_completed',
+    #'fedimg_image_test_failed',
+    #'fedimg_image_test_started',
+    #'fedimg_image_test_state',
+    #'fedimg_image_upload_completed',
+    #'fedimg_image_upload_failed',
+    #'fedimg_image_upload_started',
+    #'fedimg_image_upload_state',
+
+    ## I *do* want to be notified of *all* my own jenkins activity.
+    #'jenkins_build_aborted',
+    #'jenkins_build_unstable',
+    #'jenkins_build_failed',
+    #'jenkins_build_start',
+    #'jenkins_build_passed',
+    #'jenkins_build_notbuilt',
+
+    ## Pretty cool to get notifications of your own kerneltest uploads.
+    #'kerneltest_upload_new',
+    #'kerneltest_release_new',
+    #'kerneltest_release_edit',
+
+    ## Here, only ignore koji builds that are **starting**.  We *do*
+    ## want to get notified of all builds that finish (in any way:  success,
+    ## failure, or cancellation).
+    #'koji_scratch_build_cancelled',
+    #'koji_scratch_build_state_change',
+    #'koji_scratch_build_completed',
+    #'koji_scratch_build_failed',
+    'koji_scratch_build_started',
+    #'koji_build_cancelled',
+    #'koji_build_state_change',
+    #'koji_build_completed',
+    #'koji_build_deleted',
+    #'koji_build_failed',
+    'koji_build_started',
+
+    ## Lastly, we can hide all of this "behind the scenes" stuff from users.
+    'koji_tag',
+    'koji_untag',
+    'koji_repo_done',
+    'koji_repo_init',
+    'koji_package_list_change',
+
+    ## Don't hide any koschei stuff from users.  It is pretty interesting stuff
+    #'koschei_group',
+    #'koschei_package_state_change',
+
+    ## Go ahead and ignore all mailman stuff since you should be getting it by
+    ## email anyways.
+    'mailman_receive',
+
+    ## I actually want to know about all the nuancier stuff associated with me,
+    ## if I'm ever in an election.
+    #'nuancier_candidate_new',
+    #'nuancier_candidate_approved',
+    #'nuancier_election_new',
+    #'nuancier_candidate_denied',
+    #'nuancier_election_update',
+
+    'planet_post_new',
+
+    ## Ignore all the compose stuff.. but this can be commented out since
+    ## compose messages are associated with neither a username nor a package.
+    #'compose_branched_complete',
+    #'compose_epelbeta_complete',
+    #'compose_rawhide_complete',
+    #'compose_branched_start',
+    #'compose_rawhide_start',
+    #'compose_branched_mash_complete',
+    #'compose_rawhide_mash_complete',
+    #'compose_branched_mash_start',
+    #'compose_rawhide_mash_start',
+    #'compose_branched_pungify_complete',
+    #'compose_rawhide_pungify_complete',
+    #'compose_branched_pungify_start',
+    #'compose_rawhide_pungify_start',
+    #'compose_branched_rsync_complete',
+    #'compose_rawhide_rsync_complete',
+    #'compose_branched_rsync_start',
+    #'compose_rawhide_rsync_start',
 ]
 
 
@@ -116,6 +310,7 @@ def create_defaults_for(session, user, only_for=None, detail_values=None):
             else:
                 log.warn("No such context %r is in the DB." % name)
 
+    # For each context, build two big filters
     for context in contexts():
         pref = fmn.lib.models.Preference.load(session, user, context)
         if not pref:
@@ -123,25 +318,41 @@ def create_defaults_for(session, user, only_for=None, detail_values=None):
             pref = fmn.lib.models.Preference.create(
                 session, user, context, detail_value=value)
 
-        # Add rules that look for this user
-        qualifier_path = 'fmn.rules:user_filter'
-        for name, rule_path in generic_rule_path_defaults:
-            filt = fmn.lib.models.Filter.create(session, name)
-            filt.add_rule(session, valid_paths, rule_path)
-            filt.add_rule(session, valid_paths, qualifier_path, fasnick=nick)
-            pref.add_filter(session, filt, notify=False)
+        # Add a filter that looks for this user
+        filt = fmn.lib.models.Filter.create(
+            session, "Events referring to my username")
+        filt.add_rule(session, valid_paths,
+                      "fmn.rules:user_filter", fasnick=nick)
 
-        # Add rules that look for this user's packages
-        qualifier_path = 'fmn.rules:user_package_filter'
-        for name, rule_path in package_rule_path_defaults:
-            filt = fmn.lib.models.Filter.create(session, name)
-            filt.add_rule(session, valid_paths, rule_path)
-            filt.add_rule(session, valid_paths, qualifier_path, fasnick=nick)
-            pref.add_filter(session, filt, notify=False)
+        # Right off the bat, ignore all messages from non-primary kojis.
+        filt.add_rule(session, valid_paths,
+                      "fmn.rules:koji_instance",
+                      instance="ppc,s390,arm",
+                      negated=True)
 
-        # Lastly, provide one catchall
-        name = 'Anything involving my username'
-        rule_path = 'fmn.rules:user_filter'
-        filt = fmn.lib.models.Filter.create(session, name)
-        filt.add_rule(session, valid_paths, rule_path, fasnick=nick)
+        # And furthermore exclude lots of message types
+        for code_path in exclusion_username + exclusion_mutual:
+            filt.add_rule(
+                session, valid_paths, "fmn.rules:%s" % code_path, negated=True)
+
+        pref.add_filter(session, filt, notify=True)
+
+
+        # Add a filter that looks for packages of this user
+        filt = fmn.lib.models.Filter.create(
+            session, "Events on packages that I own")
+        filt.add_rule(session, valid_paths,
+                      "fmn.rules:user_package_filter", fasnick=nick)
+
+        # Right off the bat, ignore all messages from non-primary kojis.
+        filt.add_rule(session, valid_paths,
+                      "fmn.rules:koji_instance",
+                      instance="ppc,s390,arm",
+                      negated=True)
+
+        # And furthermore, exclude lots of message types
+        for code_path in exclusion_packages + exclusion_mutual:
+            filt.add_rule(
+                session, valid_paths, "fmn.rules:%s" % code_path, negated=True)
+
         pref.add_filter(session, filt, notify=True)

--- a/fmn/lib/defaults.py
+++ b/fmn/lib/defaults.py
@@ -78,7 +78,7 @@ exclusion_username = [
     'fmn_preference_update',
     'fmn_confirmation_update',
 
-    # Ignore all meetbot stuff about meetings I am involved in.  bocecha
+    # Ignore all meetbot stuff about meetings I am involved in.  bochecha
     # pointed it out that this was ridiculous.
     'meetbot_meeting_complete',
     'meetbot_meeting_start',

--- a/fmn/lib/defaults.py
+++ b/fmn/lib/defaults.py
@@ -14,9 +14,6 @@ log = logging.getLogger(__name__)
 #                     filters)
 
 exclusion_packages = [
-    # If this is a message about a package of mine, **and** i'm responsible for
-    # it, then don't trigger this filter.  Rely on the other one.
-    'user_filter',
 ]
 
 exclusion_username = [
@@ -343,6 +340,13 @@ def create_defaults_for(session, user, only_for=None, detail_values=None):
             session, "Events on packages that I own")
         filt.add_rule(session, valid_paths,
                       "fmn.rules:user_package_filter", fasnick=nick)
+
+        # If this is a message about a package of mine, **and** i'm responsible
+        # for it, then don't trigger this filter.  Rely on the previous one.
+        filt.add_rule(session, valid_paths,
+                      "fmn.rules:user_filter",
+                      fasnick=nick,
+                      negated=True)
 
         # Right off the bat, ignore all messages from non-primary kojis.
         filt.add_rule(session, valid_paths,

--- a/fmn/lib/defaults.py
+++ b/fmn/lib/defaults.py
@@ -159,13 +159,13 @@ exclusion_mutual = [
 
     # No need to tell me about copr starts, I just want to know about completed
     # stuff.
-    'copr_build_end',
-    'copr_build_failed',
-    'copr_build_skipped',
-    #'copr_build_start',
-    'copr_build_success',
-    #'copr_chroot_start',
-    #'copr_worker_create',
+    #'copr_build_end',
+    #'copr_build_failed',
+    #'copr_build_skipped',
+    'copr_build_start',
+    #'copr_build_success',
+    'copr_chroot_start',
+    'copr_worker_create',
 
     ## No need to tell me about any fedora-elections stuff, but this should
     ## never match anyways (it won't relate to my username or a package of

--- a/fmn/lib/models.py
+++ b/fmn/lib/models.py
@@ -288,12 +288,13 @@ class Rule(BASE):
             raise ValueError("%r is not a valid code_path" % code_path)
 
     @classmethod
-    def create_from_code_path(cls, session, valid_paths, code_path, **kw):
+    def create_from_code_path(cls, session, valid_paths, code_path,
+                              negated=False, **kw):
 
         # This will raise an exception if invalid
         Rule.validate_code_path(valid_paths, code_path, **kw)
 
-        filt = cls(code_path=code_path)
+        filt = cls(code_path=code_path, negated=negated)
         filt.arguments = kw
 
         session.add(filt)


### PR DESCRIPTION
This should fix fedora-infra/fmn#29.

It totally re-works the defaults.  It used to create many many filters that
looked like this:

- Include messages that match my username *and* are bodhi messages.
- Include messages that match my username *and* are koji messages.
- Include messages that match my username *and* are wiki messages.
...

etc, etc..

This new approach creates only two filters:

- Include messages that match my username *but are not* among a list of
  undesired messages.
- Include messages that match my packages *but are not* among a *different*
  list of undesired messages.

The reasoning behind why some message types are put in one list and another are
documented with inline comments in that ``fmn/lib/defaults.py`` file.  I'd
appreciate review and discussion over this since there have been a lot of
comments on it in fedora-infra/fmn#29.  Thanks!