### PR TITLE
If a rule throws an exception, then the match should fail.

### DIFF
--- a/fmn/lib/__init__.py
+++ b/fmn/lib/__init__.py
@@ -86,6 +86,8 @@ def matches(filter, message, valid_paths, rule_cache, config):
                 return False
         except Exception as e:
             log.exception(e)
+            # If something throws an exception then we do *not* have a match.
+            return False
 
     # Then all rules matched on this filter..
     return True


### PR DESCRIPTION
This even happens sporadically, sometimes when FAS is unavailable and
the app needs to query FAS to figure out whose IRC nick is whose.

This should fix fedora-infra/fmn#33 (at least, it is one of possibly
many causes).