### PR TITLE
Add a new hinting submodule.

### DIFF
--- a/fmn/lib/__init__.py
+++ b/fmn/lib/__init__.py
@@ -112,6 +112,8 @@ def load_rules(root='fmn.rules'):
 
     module = __import__(root, fromlist=[root.split('.')[0]])
 
+    hinting_helpers = fmn.lib.hinting.__dict__.values()
+
     rules = {}
     for name in dir(module):
         obj = getattr(module, name)
@@ -120,8 +122,8 @@ def load_rules(root='fmn.rules'):
         if not callable(obj):
             continue
 
-        # Ignore our decorator
-        if name == 'hint':
+        # Ignore our decorator and its friends
+        if obj in hinting_helpers:
             continue
 
         doc = inspect.getdoc(obj)

--- a/fmn/lib/__init__.py
+++ b/fmn/lib/__init__.py
@@ -115,7 +115,13 @@ def load_rules(root='fmn.rules'):
     rules = {}
     for name in dir(module):
         obj = getattr(module, name)
+
+        # Ignore non-callables.
         if not callable(obj):
+            continue
+
+        # Ignore our decorator
+        if name == 'hint':
             continue
 
         doc = inspect.getdoc(obj)

--- a/fmn/lib/__init__.py
+++ b/fmn/lib/__init__.py
@@ -156,6 +156,7 @@ def load_rules(root='fmn.rules'):
             'doc-no-links': doc_no_links.strip(),
             'args': inspect.getargspec(obj)[0],
             'datanommer-hints': getattr(obj, 'hints', {}),
+            'hints-invertible': getattr(obj, 'hinting_invertible', True),
         }
 
     rules = OrderedDict(

--- a/fmn/lib/__init__.py
+++ b/fmn/lib/__init__.py
@@ -150,6 +150,7 @@ def load_rules(root='fmn.rules'):
             'doc': doc.strip(),
             'doc-no-links': doc_no_links.strip(),
             'args': inspect.getargspec(obj)[0],
+            'datanommer-hints': getattr(obj, 'hints', {}),
         }
 
     rules = OrderedDict(

--- a/fmn/lib/__init__.py
+++ b/fmn/lib/__init__.py
@@ -10,8 +10,6 @@ import bs4
 import docutils.examples
 import markupsafe
 
-import fedmsg.utils
-
 from collections import defaultdict
 
 try:
@@ -44,7 +42,6 @@ def recipients(preferences, message, valid_paths, config):
         if (user['openid'], context['name']) in notified:
             continue
 
-        filters = preference['filters']
         for filter in preference['filters']:
             if matches(filter, message, valid_paths, rule_cache, config):
                 for detail_value in preference['detail_values']:

--- a/fmn/lib/__init__.py
+++ b/fmn/lib/__init__.py
@@ -1,5 +1,6 @@
 """ Fedora Notifications internal API """
 
+import fmn.lib.hinting
 import fmn.lib.models
 
 import inspect

--- a/fmn/lib/hinting.py
+++ b/fmn/lib/hinting.py
@@ -1,0 +1,64 @@
+""" Helpers for "datanommer hints" for rules.
+
+Rules can optionally define a "hint" for a datanommer query.  For
+instance, if a rule has to do with filtering for bodhi messages, then a
+provided hint could be {'category': 'bodhi'}.  This simply speeds up the
+process of looking for potential message matches in the history by
+letting the database server do some of the work for us.  Without this, we
+have to comb through literally every message ever and then try to see
+what matches and what doesn't in python-land:  Slow!
+
+Rules define their hints with the @hint decorator defined here.
+
+When querying datanommer, the ``gather_hinting`` helper here can be used to
+construct the hint dict for ``datanommer.grep(..., **hints)``.
+"""
+
+import collections
+import functools
+
+import fedmsg.config
+
+
+def hint(invertible=True, **hints):
+    """ A decorator that can optionally hang datanommer hints on a rule. """
+    def wrapper(fn):
+        @functools.wraps(fn)
+        def replacement(*args, **kwargs):
+            return fn(*args, **kwargs)
+
+        # Hang hints on the function.
+        replacement.hints = hints
+        replacement.hinting_invertible = invertible
+        return replacement
+
+    return wrapper
+
+
+def prefixed(topic, prefix='org.fedoraproject'):
+    config = fedmsg.config.load_config()  # This is memoized for us.
+    return '.'.join([prefix, config['environment'], topic])
+
+
+def gather_hinting(filter, valid_paths):
+    """ Construct hint arguments for datanommer from a filter. """
+
+    hinting = collections.defaultdict(list)
+    for rule in filter.rules:
+        root, name = rule.code_path.split(':', 1)
+        info = valid_paths[root][name]
+        for key, value in info['datanommer-hints'].items():
+
+            # If the rule is inverted, but the hint is not invertible, then
+            # there is no hinting we can provide.  Carry on.
+            if rule.negated and not info['hints-invertible']:
+                continue
+
+            # Otherwise, construct the inverse hint if necessary
+            if rule.negated:
+                key = 'not_' + key
+
+            # And tack it on.
+            hinting[key] += value
+
+    return hinting


### PR DESCRIPTION
This allows rules to declare hints to datanommer so that they can be queried
for much more efficiently.

As an extra, we also get new tests in fmn.rules that compare the hinting
declarations against the actual rule to make sure they match.  :)  (That's in
another PR on fmn.rules).

There will be two more PRs to follow in fmn.rules and fmn.web.