### PR TITLE
Fix bug in cache-key generation.

### DIFF
--- a/fmn/lib/models.py
+++ b/fmn/lib/models.py
@@ -262,7 +262,9 @@ class Rule(BASE):
 
     @property
     def cache_key(self):
-        return hashlib.sha256(self.code_path + self._arguments).hexdigest()
+        return hashlib.sha256(
+            self.code_path + str(self.negated) + self._arguments
+        ).hexdigest()
 
     @hybrid_property
     def arguments(self):


### PR DESCRIPTION
This one has been haunting me all day.

The symptom was that I wasn't getting *any* messages from my second IRC
filter from the new defaults (which I'm glad I didn't announce yet.
They don't work without this).

The explanation is that I have one filter, which first checks if
user=ralph is in the message.  If it is, and some other things are not
true about the message, then it gets forwarded to me.

The other rule checks for packages I own (which works), but then it
checks if user=ralph is *not* in the message.  **That* check always
evaluated incorrectly -- it turns out the value from the other filter
was being cached and carried over.  The distinguishing thing between
them is that *one is negated and the other is not*.  By factoring
``self.negated`` into the calculation of a Rule's ``cache_key``, they
fall into different slots in the cache and everything works.