### PR TITLE
Multiprocessing.

### DIFF
--- a/fmn/lib/__init__.py
+++ b/fmn/lib/__init__.py
@@ -38,8 +38,7 @@ def recipients(preferences, message, valid_paths, config, pool=None):
     arguments = [(p, message, valid_paths, config) for p in preferences]
 
     if not pool:
-        fn = lambda args: _recipient(*args)
-        result_list = map(fn, arguments)
+        result_list = [_recipient(*a) for a in arguments]
     else:
         if not pool.targeted:
             pool.target(_recipient)

--- a/fmn/lib/multiproc.py
+++ b/fmn/lib/multiproc.py
@@ -61,12 +61,17 @@ class FixedPool(object):
         if not self.targeted:
             log.warning('No need to close pool.  Not yet targeted.')
             return
+
         log.info('Closing fmn multiproc pool.')
         for _ in self.processes:
             self.incoming.put(StopIteration)
-        log.debug('Waiting on workers to die.')
-        for p in self.processes:
-            p.join()
+
+        # XXX - we could call process.join() on all of our child processes, but
+        # that only works if *this* process is the same PID as the process that
+        # created them, and that isn't always the case when under the care of
+        # Twisted.  So, we'll just omit that.  Twisted cleans itself up nicely
+        # without it.
+
         self.processes = []
         log.info('Multiproc pool closed.')
 

--- a/fmn/lib/multiproc.py
+++ b/fmn/lib/multiproc.py
@@ -18,7 +18,7 @@ class FixedPool(object):
     def __init__(self, N):
         log.info('Initializing fmn multiproc pool, size %i for thread %s' % (
             N, threading.current_thread().name))
-        self.incoming = Queue(1)
+        self.incoming = Queue()
         self.outgoing = Queue()
         self.processes = []
         self.N = N

--- a/fmn/lib/multiproc.py
+++ b/fmn/lib/multiproc.py
@@ -1,0 +1,70 @@
+import logging
+
+from multiprocessing import Queue, Process
+
+__all__ = ['FixedPool']
+
+log = logging.getLogger('fedmsg')
+
+
+class FixedPool(object):
+    """ Our own multiprocessing pool.
+
+    This avoids the 'importable' requirement of multiprocessing.Pool.
+    """
+    def __init__(self, N):
+        log.debug('Initializing fmn multiproc pool, size %i' % N)
+        self.incoming = Queue(1)
+        self.outgoing = Queue()
+        self.processes = []
+        self.N = N
+
+    @property
+    def targeted(self):
+        # If I have processes, then I am targetted on some func.
+        return bool(self.processes)
+
+    def target(self, fn):
+        log.info('Multiprocessing pool targeting %r' % fn)
+        if self.targeted:
+            self.close()
+
+        args = (fn, self.incoming, self.outgoing)
+        self.processes = [
+            Process(target=work, args=args) for i in range(self.N)]
+
+        for p in self.processes:
+            p.daemon = True
+            p.start()
+
+        log.info('Multiprocessing pool targeting done.')
+
+    def apply(self, items):
+        """ Items are not guaranteed to come back in the same order. """
+        if not self.targeted:
+            raise ValueError('.target(fn) must be called before .apply(items)')
+        for item in items:
+            if not isinstance(item, tuple):
+                item = item,
+            self.incoming.put(item)
+        return set(self.outgoing.get() for i in range(len(items)))
+
+    def close(self):
+        if not self.targeted:
+            log.warning('No need to close pool.  Not yet targeted.')
+            return
+        log.info('Closing fmn multiproc pool.')
+        for _ in self.processes:
+            self.incoming.put(StopIteration)
+        log.debug('Waiting on workers to die.')
+        for p in self.processes:
+            p.join()
+        self.processes = []
+        log.info('Multiproc pool closed.')
+
+def work(fn, incoming, outgoing):
+    while True:
+        args = incoming.get()
+        if args is StopIteration:
+            break
+        outgoing.put(fn(*args))

--- a/fmn/lib/multiproc.py
+++ b/fmn/lib/multiproc.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import threading
 import traceback as tb
 
 from multiprocessing import Queue, Process
@@ -15,7 +16,8 @@ class FixedPool(object):
     This avoids the 'importable' requirement of multiprocessing.Pool.
     """
     def __init__(self, N):
-        log.debug('Initializing fmn multiproc pool, size %i' % N)
+        log.info('Initializing fmn multiproc pool, size %i for thread %s' % (
+            N, threading.current_thread().name))
         self.incoming = Queue(1)
         self.outgoing = Queue()
         self.processes = []

--- a/fmn/lib/multiproc.py
+++ b/fmn/lib/multiproc.py
@@ -47,7 +47,7 @@ class FixedPool(object):
             if not isinstance(item, tuple):
                 item = item,
             self.incoming.put(item)
-        return set(self.outgoing.get() for i in range(len(items)))
+        return [self.outgoing.get() for i in range(len(items))]
 
     def close(self):
         if not self.targeted:

--- a/fmn/lib/tests/test_multiproc.py
+++ b/fmn/lib/tests/test_multiproc.py
@@ -66,3 +66,20 @@ class TestMultiproc(fmn.lib.tests.Base):
             eq_(set(results), set([3, 4]))
         finally:
             pool.close()
+
+    def test_inner_exception(self):
+        pool = fmn.lib.multiproc.FixedPool(5)
+
+        error_message = "oh no!"
+
+        def fn(x):
+            raise ValueError(error_message)
+
+        try:
+            pool.target(fn)
+            pool.apply(['whatever'])
+            assert False
+        except ValueError as e:
+            assert error_message in e.message
+        finally:
+            pool.close()

--- a/fmn/lib/tests/test_multiproc.py
+++ b/fmn/lib/tests/test_multiproc.py
@@ -1,0 +1,68 @@
+from nose.tools import eq_, raises
+
+import fmn.lib.tests
+import fmn.lib.multiproc
+
+
+class TestMultiproc(fmn.lib.tests.Base):
+    def test_single_map(self):
+        pool = fmn.lib.multiproc.FixedPool(1)
+        try:
+            def fn(x):
+                return x + 2
+            pool.target(fn)
+            results = pool.apply(range(2))
+            eq_(results, set([2, 3]))
+        finally:
+            pool.close()
+
+    def test_multi_map(self):
+        pool = fmn.lib.multiproc.FixedPool(5)
+        try:
+            def fn(x):
+                return x + 2
+            pool.target(fn)
+            results = pool.apply(range(10))
+            eq_(results, set([2, 3, 4, 5, 6, 7, 8, 9, 10, 11]))
+        finally:
+            pool.close()
+
+    def test_is_targeted(self):
+        pool = fmn.lib.multiproc.FixedPool(5)
+        eq_(pool.targeted, False)
+        try:
+            def fn(x):
+                return x + 2
+            pool.target(fn)
+            eq_(pool.targeted, True)
+        finally:
+            pool.close()
+
+    @raises(ValueError)
+    def test_target_before_apply(self):
+        pool = fmn.lib.multiproc.FixedPool(5)
+        pool.apply([1, 2, 3])
+
+
+    def test_reuse(self):
+        pool = fmn.lib.multiproc.FixedPool(5)
+
+        def fn1(x):
+            return x + 1
+
+        def fn2(x):
+            return x + 2
+
+        try:
+            pool.target(fn1)
+            results = pool.apply([1, 2])
+            eq_(results, set([2, 3]))
+        finally:
+            pool.close()
+
+        try:
+            pool.target(fn2)
+            results = pool.apply([1, 2])
+            eq_(results, set([3, 4]))
+        finally:
+            pool.close()

--- a/fmn/lib/tests/test_multiproc.py
+++ b/fmn/lib/tests/test_multiproc.py
@@ -12,7 +12,7 @@ class TestMultiproc(fmn.lib.tests.Base):
                 return x + 2
             pool.target(fn)
             results = pool.apply(range(2))
-            eq_(results, set([2, 3]))
+            eq_(set(results), set([2, 3]))
         finally:
             pool.close()
 
@@ -23,7 +23,7 @@ class TestMultiproc(fmn.lib.tests.Base):
                 return x + 2
             pool.target(fn)
             results = pool.apply(range(10))
-            eq_(results, set([2, 3, 4, 5, 6, 7, 8, 9, 10, 11]))
+            eq_(set(results), set([2, 3, 4, 5, 6, 7, 8, 9, 10, 11]))
         finally:
             pool.close()
 
@@ -56,13 +56,13 @@ class TestMultiproc(fmn.lib.tests.Base):
         try:
             pool.target(fn1)
             results = pool.apply([1, 2])
-            eq_(results, set([2, 3]))
+            eq_(set(results), set([2, 3]))
         finally:
             pool.close()
 
         try:
             pool.target(fn2)
             results = pool.apply([1, 2])
-            eq_(results, set([3, 4]))
+            eq_(set(results), set([3, 4]))
         finally:
             pool.close()


### PR DESCRIPTION
There's a long story to this.  Here it is in bullet form:

* FMN was too slow.  I implemented multiple threads so that many workers could operate at the same time.  FMN got a little faster.
* FMN was still too slow.  I took a lot of time (months) and implemented tons of caching.  FMN needs to talk to pkgdb, to FAS, and to its own DB often.  With smart caching, that stuff is now cut down to a minimum.
* FMN was still too slow.  I cranked up the number of threads yesterday from 6 to 12, and got 0% performance improvement.  The CPUs were not all being used!
* At this point it occurs to me that with the caching in place (no I/O happening), the threads are now CPU-bound, and [cpu bound threads suffer a performance penalty from the GIL](https://wiki.python.org/moin/GlobalInterpreterLock).
* I wanted to implement multi-processing at the daemon level using a [message distribution mechanism](http://threebean.org/blog/hashspace/) and started work on it, but then realized this morning that it won't work for FMN.  The daemons need to **share the IRC connection** so that fmn messages come from the same IRC nick.
* Which brings me to this implementation, a multiproc pool that only handles the computationally expensive portion of FMN's job.
* I was going to use the stdlib ``multiprocessing.Pool`` object, but it suffers from this design issue where it 1) can't do *args expansion and 2) the function being mapped has to be importable (which made doing this super hard).  So, I implemented and wrote tests for my own multiproc pool here.