### PR TITLE
Introduce callable hints.

### DIFF
--- a/fmn/lib/__init__.py
+++ b/fmn/lib/__init__.py
@@ -169,6 +169,7 @@ def load_rules(root='fmn.rules'):
             'args': inspect.getargspec(obj)[0],
             'datanommer-hints': getattr(obj, 'hints', {}),
             'hints-invertible': getattr(obj, 'hinting_invertible', True),
+            'hints-callable': getattr(obj, 'hinting_callable', None),
         }
 
     rules = OrderedDict(

--- a/fmn/lib/hinting.py
+++ b/fmn/lib/hinting.py
@@ -43,7 +43,7 @@ def prefixed(topic, prefix='org.fedoraproject'):
     return '.'.join([prefix, config['environment'], topic])
 
 
-def gather_hinting(filter, valid_paths):
+def gather_hinting(config, filter, valid_paths):
     """ Construct hint arguments for datanommer from a filter. """
 
     hinting = collections.defaultdict(list)
@@ -52,7 +52,7 @@ def gather_hinting(filter, valid_paths):
         info = valid_paths[root][name]
 
         if info['hints-callable']:
-            result = info['hints-callable'](**rule.arguments)
+            result = info['hints-callable'](config=config, **rule.arguments)
             for key, values in result.items():
                 hinting[key].extend(values)
 

--- a/fmn/lib/hinting.py
+++ b/fmn/lib/hinting.py
@@ -20,7 +20,7 @@ import decorator
 import fedmsg.config
 
 
-def hint(invertible=True, **hints):
+def hint(invertible=True, callable=None, **hints):
     """ A decorator that can optionally hang datanommer hints on a rule. """
 
     @decorator.decorator
@@ -32,6 +32,7 @@ def hint(invertible=True, **hints):
         # Hang hints on the wrapped function.
         wrapped.hints = hints
         wrapped.hinting_invertible = invertible
+        wrapped.hinting_callable = callable
         return wrapped
 
     return wrapper_wrapper
@@ -49,6 +50,12 @@ def gather_hinting(filter, valid_paths):
     for rule in filter.rules:
         root, name = rule.code_path.split(':', 1)
         info = valid_paths[root][name]
+
+        if info['hints-callable']:
+            result = info['hints-callable'](**rule.arguments)
+            for key, values in result.items():
+                hinting[key].extend(values)
+
         for key, value in info['datanommer-hints'].items():
 
             # If the rule is inverted, but the hint is not invertible, then

--- a/fmn/lib/tests/example_rules.py
+++ b/fmn/lib/tests/example_rules.py
@@ -18,3 +18,12 @@ def hint_masked_rule(config, message, argument1):
     For real, it is a docstring.
     """
     return True
+
+
+def _func(argument1):
+    return {'the-hint-is': [argument1]}
+
+
+@fmn.lib.hinting.hint(callable=_func)
+def callable_hint_masked_rule(config, message, argument1):
+    return True

--- a/fmn/lib/tests/example_rules.py
+++ b/fmn/lib/tests/example_rules.py
@@ -20,7 +20,7 @@ def hint_masked_rule(config, message, argument1):
     return True
 
 
-def _func(argument1):
+def _func(config, argument1):
     return {'the-hint-is': [argument1]}
 
 

--- a/fmn/lib/tests/test_hinting.py
+++ b/fmn/lib/tests/test_hinting.py
@@ -33,5 +33,6 @@ class TestHintDecoration(fmn.lib.tests.Base):
 
         filter_obj = MockFilter()
 
-        hints = fmn.lib.hinting.gather_hinting(filter_obj, self.valid_paths)
+        hints = fmn.lib.hinting.gather_hinting(
+            self.config, filter_obj, self.valid_paths)
         eq_(hints, {'the-hint-is': ['cowabunga']})

--- a/fmn/lib/tests/test_hinting.py
+++ b/fmn/lib/tests/test_hinting.py
@@ -1,5 +1,7 @@
 from nose.tools import eq_
 
+import fmn.lib
+import fmn.lib.hinting
 import fmn.lib.tests
 
 
@@ -13,3 +15,23 @@ class TestHintDecoration(fmn.lib.tests.Base):
         eq_(len(rule['args']), 3)
 
         eq_(rule['datanommer-hints'], {'categories': ['whatever']})
+
+    def test_hint_callable(self):
+        rules = self.valid_paths['fmn.lib.tests.example_rules']
+        rule = rules['callable_hint_masked_rule']
+        eq_(len(rule['args']), 3)
+        eq_(rule['datanommer-hints'], {})
+
+        class MockRule(object):
+            code_path = 'fmn.lib.tests.example_rules:callable_hint_masked_rule'
+            arguments = {
+                'argument1': 'cowabunga',
+            }
+
+        class MockFilter(object):
+            rules = [MockRule()]
+
+        filter_obj = MockFilter()
+
+        hints = fmn.lib.hinting.gather_hinting(filter_obj, self.valid_paths)
+        eq_(hints, {'the-hint-is': ['cowabunga']})


### PR DESCRIPTION
The way that fmn *rules* work is that they're design to take a message when it
arrives and return True or False if they *match* that message.  That's all well
and good.

It got tricky when I wanted to show in the web ui what messages from the past
would match your configuration of rules.  I had to pull **all** messages from
datanommer and then apply the rules to each one in python.  *Way* too slow.

To fix this, I added hints, which allowed the rules to declare some arguments
that they wanted to pass on to the datanommer query, so that we wouldn't have
to comb through *all* messages in the history, just some of the more likely
ones.  This worked out in most cases.

The tricky ones were the rules that *accepted arguments*, like say the one that
says "only match messages if they are about ``fasnick``".  There was no way to
know what the value of ``fasnick`` would be, just given the rule itself.

This code adds a new argument to the ``@hint`` decorator called
``callable=...``.  It allows the rule to define a function that, when called,
will return the appropriate hint -- *deferring* the construction of the hint
until a time when the *arguments* to the rule are known.  This allows us to construct hints for the user filter that look like this:

```python
@hint(callable=lambda config, fasnick: dict(usernames=[fasnick]))
def user_filter(config, message, fasnick=None, *args, **kw):
    # ....
```