### PR TITLE
Ignore all anitya notifications

### DIFF
--- a/fmn/lib/defaults.py
+++ b/fmn/lib/defaults.py
@@ -57,9 +57,6 @@ exclusion_username = [
     # Ignore all of my own tagger stuff
     'fedoratagger_catchall',
 
-    # Ignore all of my own anitya stuff
-    'anitya_catchall',
-
     # Ignore all of my own wiki stuff.
     'wiki_catchall',
 
@@ -186,6 +183,12 @@ exclusion_mutual = [
     # Go ahead and ignore all summershum messages by default.  @jwboyer
     # complained rightly https://github.com/fedora-infra/fmn/issues/27
     'summershum_catchall',
+
+    # Ignore all anitya stuff:
+    # - don't notify me about my own actions there
+    # - don't notify me about updates to my packages, because the-new-hotness
+    #   will already do that if I enabled monitoring of my packages in pkgdb
+    'anitya_catchall',
 ]
 
 


### PR DESCRIPTION
We were already ignoring anitya notifications for the user's own actions.

However, the other anitya notifications are about new upstream versions being found.

If the maintainer disabled monitoring in pkgdb, then they certainly shouldn't receive notifications that a new version was found in anitya.

And if the maintainer enabled monitoring in pkgdb, then the-new-hotness will already open a bug report, and bugzilla will notify them.

As a result, there really is no reason to receive any anitya notification by default.

This helps with fedora-infra/fmn#64