### PR TITLE
Implement one-shot filters

### DIFF
--- a/fmn/lib/__init__.py
+++ b/fmn/lib/__init__.py
@@ -51,6 +51,7 @@ def recipients(preferences, message, valid_paths, config):
                         context['detail_name']: detail_value,
                         'filter_name': filter['name'],
                         'filter_id': filter['id'],
+                        'filter_oneshot': filter['oneshot'],
                         'markup_messages': preference['markup_messages'],
                         'triggered_by_links': preference['triggered_by_links'],
                         'shorten_links': preference['shorten_links'],

--- a/fmn/lib/tests/test_models.py
+++ b/fmn/lib/tests/test_models.py
@@ -60,6 +60,21 @@ class TestBasics(fmn.lib.tests.Base):
             detail_name="registration id", icon="phone")
         eq_(len(fmn.lib.models.Context.all(self.sess)), 2)
 
+    def test_filter_oneshot(self):
+        filter = fmn.lib.models.Filter.create(self.sess, name="test filter")
+        filter.oneshot = True
+        eq_(filter.active, True)
+        eq_(filter.oneshot, True)
+        filter.fired(self.sess)
+        eq_(filter.active, False)
+
+        filter = fmn.lib.models.Filter.create(self.sess, name="test filter 2")
+        filter.oneshot = False
+        eq_(filter.active, True)
+        eq_(filter.oneshot, False)
+        filter.fired(self.sess)
+        eq_(filter.active, True)
+
 
 class TestPreferences(fmn.lib.tests.Base):
     def setUp(self):

--- a/fmn/lib/tests/test_recipients.py
+++ b/fmn/lib/tests/test_recipients.py
@@ -101,6 +101,7 @@ class TestRecipients(fmn.lib.tests.Base):
             'user': 'ralph.id.fedoraproject.org',
             'filter_name': 'test filter',
             'filter_id': 1,
+            'filter_oneshot': False,
         })
 
     def test_miss_recipients_list(self):
@@ -171,6 +172,7 @@ class TestRecipients(fmn.lib.tests.Base):
             'user': 'ralph.id.fedoraproject.org',
             'filter_name': 'test filter',
             'filter_id': 1,
+            'filter_oneshot': False
         }
         eq_(recipients['irc'][0], expected)
 
@@ -203,6 +205,7 @@ class TestRecipients(fmn.lib.tests.Base):
             'user': 'ralph.id.fedoraproject.org',
             'filter_name': 'test filter',
             'filter_id': 1,
+            'filter_oneshot': False,
         })
 
     def test_load_preferences(self):


### PR DESCRIPTION
After being ran one, call fired() to disable them

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>