### PR TITLE
Allow callable hints to be inverted.

### DIFF
--- a/fmn/lib/hinting.py
+++ b/fmn/lib/hinting.py
@@ -55,10 +55,20 @@ def gather_hinting(config, filter, valid_paths):
         info = valid_paths[root][name]
 
         if info['hints-callable']:
+            # Call the callable hint to get its values
             result = info['hints-callable'](config=config, **rule.arguments)
+
+            # If the rule is inverted, but the hint is not invertible, then
+            # there is no hinting we can provide.  Carry on.
+            if rule.negated and not info['hints-invertible']:
+                continue
+
             for key, values in result.items():
+                # Negate the hint if necessary
+                key = 'not_' + key if rule.negated else key
                 hinting[key].extend(values)
 
+        # Then, finish off with all the other ordinary, non-callable hints
         for key, value in info['datanommer-hints'].items():
 
             # If the rule is inverted, but the hint is not invertible, then

--- a/fmn/lib/hinting.py
+++ b/fmn/lib/hinting.py
@@ -67,8 +67,7 @@ def gather_hinting(config, filter, valid_paths):
                 continue
 
             # Otherwise, construct the inverse hint if necessary
-            if rule.negated:
-                key = 'not_' + key
+            key = 'not_' + key if rule.negated else key
 
             # And tack it on.
             hinting[key] += value

--- a/fmn/lib/tests/test_hinting.py
+++ b/fmn/lib/tests/test_hinting.py
@@ -27,6 +27,7 @@ class TestHintDecoration(fmn.lib.tests.Base):
             arguments = {
                 'argument1': 'cowabunga',
             }
+            negated = False
 
         class MockFilter(object):
             rules = [MockRule()]
@@ -36,3 +37,25 @@ class TestHintDecoration(fmn.lib.tests.Base):
         hints = fmn.lib.hinting.gather_hinting(
             self.config, filter_obj, self.valid_paths)
         eq_(hints, {'the-hint-is': ['cowabunga']})
+
+    def test_inverted_hint_callable(self):
+        rules = self.valid_paths['fmn.lib.tests.example_rules']
+        rule = rules['callable_hint_masked_rule']
+        eq_(len(rule['args']), 3)
+        eq_(rule['datanommer-hints'], {})
+
+        class MockRule(object):
+            code_path = 'fmn.lib.tests.example_rules:callable_hint_masked_rule'
+            arguments = {
+                'argument1': 'cowabunga',
+            }
+            negated = True
+
+        class MockFilter(object):
+            rules = [MockRule()]
+
+        filter_obj = MockFilter()
+
+        hints = fmn.lib.hinting.gather_hinting(
+            self.config, filter_obj, self.valid_paths)
+        eq_(hints, {'not_the-hint-is': ['cowabunga']})


### PR DESCRIPTION
Fixes fedora-infra/fmn#60.