### PR TITLE
Ignore pkgdb2branch stuff by default.

### DIFF
--- a/fmn/lib/defaults.py
+++ b/fmn/lib/defaults.py
@@ -14,6 +14,10 @@ log = logging.getLogger(__name__)
 #                     filters)
 
 exclusion_packages = [
+    # Ignore cvsadmin batch stuff.
+    # See https://github.com/fedora-infra/fmn/issues/45
+    'git_pkgdb2branch_start',
+    'git_pkgdb2branch_complete',
 ]
 
 exclusion_username = [


### PR DESCRIPTION
This is okay, since packagers will be getting notifications about receiving
ACLs on the packages anyways.

Fixes fedora-infra/fmn#45.