### PR TITLE
Add "ignore mash starts" to everybody's packages filter.

### DIFF
--- a/alembic/versions/362efe8fd524_add_new_masher_rules.py
+++ b/alembic/versions/362efe8fd524_add_new_masher_rules.py
@@ -1,0 +1,61 @@
+"""Add new masher rules.
+
+Revision ID: 362efe8fd524
+Revises: 1be98d56336
+Create Date: 2015-08-26 21:10:25.561878
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '362efe8fd524'
+down_revision = '1be98d56336'
+
+from alembic import op
+import sqlalchemy as sa
+
+import fmn.lib
+
+
+path = 'fmn.rules:bodhi_masher_start'
+target = "Events on packages that I own"
+
+
+def upgrade():
+    engine = op.get_bind().engine
+    session = sa.orm.scoped_session(sa.orm.sessionmaker(bind=engine))
+
+    valid_paths = fmn.lib.load_rules(root='fmn.rules')
+
+    filters = session.query(fmn.lib.models.Filter).filter_by(name=target).all()
+    print "Found %i filters" % len(filters)
+
+    modified = 0
+    for filt in filters:
+        if len(filt.rules) < 15:
+            # Someone has changed this filter dramatically, so let's not mess
+            # with it.
+            print "Avoiding %r on %r.  Only %i rules present." % (
+                filt, filt.preference, len(filt.rules))
+            continue
+
+        modified += 1
+        filt.add_rule(session, valid_paths, path, negated=True)
+
+    print "Modified %i filters, total" % modified
+    session.commit()
+
+
+def downgrade():
+    engine = op.get_bind().engine
+    session = sa.orm.scoped_session(sa.orm.sessionmaker(bind=engine))
+
+    valid_paths = fmn.lib.load_rules(root='fmn.rules')
+
+    rules = session.query(fmn.lib.models.Rule).filter_by(code_path=path).all()
+    print "Found %i rules" % len(rules)
+
+    for rule in rules:
+        rule.filter.remove_rule(session, path)
+
+    session.commit()
+

--- a/fmn/lib/defaults.py
+++ b/fmn/lib/defaults.py
@@ -26,6 +26,10 @@ exclusion_packages = [
     # Ignore the highest-frequency/lowest-occurence ABRT messages (spam)
     'faf_report_threshold1',
     'faf_problem_threshold1',
+
+    # Ignore admin requests to start a new mash
+    # https://github.com/fedora-infra/fmn/issues/103
+    'bodhi_masher_start',
 ]
 
 exclusion_username = [


### PR DESCRIPTION
This adds an alembic script that will add a rule to ignore the mash.start
messages to everybody's filters.

It also adds the rule to new people's defaults.

This relies on fedora-infra/fmn.rules#60 and fixes fedora-infra/fmn#103.